### PR TITLE
Prevent stale cache

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -8,7 +8,7 @@ module.exports = {
   entry: './src/js/app.js',
   output: {
     path: path.join(__dirname, 'dist'),
-    filename: 'bundle.js',
+    filename: '[name].[contenthash].js',
     publicPath: ''
   },
   resolve: {
@@ -20,7 +20,9 @@ module.exports = {
     }
   },
   plugins: [
-    new MiniCssExtractPlugin(),
+    new MiniCssExtractPlugin({
+      filename: '[name].[contenthash].css'
+    }),
     new HtmlWebpackPlugin({
       template: 'src/index.html'
     })
@@ -40,6 +42,17 @@ module.exports = {
         extractComments: false
       }),
       new CssMinimizerPlugin()
-    ]
+    ],
+    moduleIds: 'deterministic',
+    runtimeChunk: 'single',
+    splitChunks: {
+      cacheGroups: {
+        vendor: {
+          test: /[\\/]node_modules[\\/]/,
+          name: 'vendors',
+          chunks: 'all',
+        },
+      },
+    },
   }
 }


### PR DESCRIPTION
When there is new build and user already visited the page, CDN will serve old assets (js, css), by hashing assets this can be prevented.

JSON and firmware is fine as expire time is set to 5min
<img width="632" alt="image" src="https://user-images.githubusercontent.com/239513/180858939-09372604-ecdb-4bef-a253-d5a5806c2e96.png">
